### PR TITLE
Fix parameter name in CI test command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           override: true
       - name: Build & run tests
-        run: cargo test --workspace --all_features
+        run: cargo test --workspace --all-features
         env:
           CARGO_INCREMENTAL: 0
           RUSTFLAGS: "-C debuginfo=0 -D warnings"


### PR DESCRIPTION
The correct parameter name is `--all-features`, not `--all_features`.
See <https://doc.rust-lang.org/cargo/commands/cargo-test.html#feature-selection>.