### PR TITLE
Fix serde tests by adding proper feature flag

### DIFF
--- a/serde_tests/Cargo.toml
+++ b/serde_tests/Cargo.toml
@@ -11,4 +11,4 @@ edition = "2021"
 
 [dependencies]
 ron = "0.7"
-petitset = {path = "..", features = ["serde"]}
+petitset = {path = "..", features = ["serde_compat"]}


### PR DESCRIPTION
Recent CI runs (e.g. https://github.com/Leafwing-Studios/petitset/actions/runs/4694044191/jobs/8321765713) fail the serde tests with compiler error like this one:

```
error[E0277]: the trait bound `PetitMap<u32, &str, 5>: serde::ser::Serialize` is not satisfied
  --> tests/serde.rs:15:42
   |
15 |     let serialization_result = to_string(&map);
   |                                --------- ^^^^ the trait `serde::ser::Serialize` is not implemented for `PetitMap<u32, &str, 5>`
   |                                |
   |                                required by a bound introduced by this call
   |
   = help: the following other types implement trait `serde::ser::Serialize`:
             &'a T
             &'a mut T
             ()
             (T0, T1)
             (T0, T1, T2)
             (T0, T1, T2, T3)
             (T0, T1, T2, T3, T4)
             (T0, T1, T2, T3, T4, T5)
           and 129 others
note: required by a bound in `ron::to_string`
  --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ron-0.7.1/src/ser/mod.rs:39:17
   |
39 |     T: ?Sized + Serialize,
   |                 ^^^^^^^^^ required by this bound in `to_string`
 ```

Looks like this is due a wrong feature name for the `serde` stuff, and this PR attemps to fix that.


__Edit:__ This seems to fix it, all CI jobs are passing with that change. :smiley: 